### PR TITLE
[BUGFIX] Fixed type suggestion to local overloaded method

### DIFF
--- a/src/phpcs/Production/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/phpcs/Production/Sniffs/Commenting/FunctionCommentSniff.php
@@ -171,7 +171,7 @@ class FunctionCommentSniff extends PHP_CS_FunctionCommentSniff
                 $suggestedNames = [];
                 foreach ($typeNames as $i => $typeName)
                 {
-                    $suggestedName = Common::suggestType($typeName);
+                    $suggestedName = self::suggestType($typeName);
                     if (in_array($suggestedName, $suggestedNames) === false)
                     {
                         $suggestedNames[] = $suggestedName;


### PR DESCRIPTION
- Instead of using the common-library, the correct static
  function is now executed. This way the annoying message
  regarding longly written parameter types (boolean, integer)
  goes away - as it should be.